### PR TITLE
Create trigger blocks only for defined triggers.

### DIFF
--- a/src/manta/logic_analyzer/fsm.py
+++ b/src/manta/logic_analyzer/fsm.py
@@ -1,5 +1,5 @@
 from amaranth import *
-from amaranth.lib.enum import IntEnum
+from amaranth.lib.enum import IntEnum, Flag
 
 from manta.io_core import IOCore
 
@@ -16,6 +16,11 @@ class TriggerModes(IntEnum):
     SINGLE_SHOT = 0
     INCREMENTAL = 1
     IMMEDIATE = 2
+
+
+class TriggerPrune(Flag):
+    TRUE = True
+    FALSE = False
 
 
 class LogicAnalyzerFSM(Elaboratable):


### PR DESCRIPTION
Adds YAML option 'trigger_pruned' support for the logic analyser to prevent the creation of trigger blocks for probes not listed as triggers. This pruning allows much higher fmax for the designs.