### PR TITLE
ci: fix coverage collection, use editable installation in CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -38,7 +38,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Coverage Report
+          name: coverage_reports
+          include-hidden-files: true
           path: |
             .coverage
             coverage.xml

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,7 @@ jobs:
           export DEB_PYTHON_INSTALL_LAYOUT=deb_system
 
           # Install Manta, with optional dev-only dependencies
-          python3 -m pip install ".[dev]"
+          python3 -m pip install -e ".[dev]"
 
       - name: Run pre-commit against all files
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Manta from Source
+      - name: Install Manta from source
         run: |
           # Make venv
           python3 -m venv venv/
@@ -43,6 +43,11 @@ jobs:
           path: |
             .coverage
             coverage.xml
+
+      - name: Show coverage report
+        run: |
+          source venv/bin/activate
+          coverage report
 
       - name: Upload results to Codecov
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,6 +36,13 @@ jobs:
           source venv/bin/activate
           make test
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Coverage Report
+          path: |
+            .coverage
+            coverage.xml
+
       - name: Upload results to Codecov
         run: |
           source venv/bin/activate

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ build/
 *.vcd
 *.out
 *.csv
+*.xml
+.coverage*
 
 # Vivado files
 *.log

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test format clean serve_docs
 test:
-	python3 -m pytest --cov-report xml --cov=src
+	python3 -m pytest --cov-report xml --cov=src/manta test/
 
 format:
 	python3 -m ruff check --select I --fix

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test format clean serve_docs
 test:
-	python3 -m pytest --cov-report xml --cov=src/manta test/
+	python3 -m pytest --cov-report xml --cov=src/manta
 
 format:
 	python3 -m ruff check --select I --fix

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test format clean serve_docs
 test:
-	python3 -m pytest --cov=.
+	python3 -m pytest --cov-report xml --cov=.
 
 format:
 	python3 -m ruff check --select I --fix

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test format clean serve_docs
 test:
-	python3 -m pytest --cov-report xml --cov=.
+	python3 -m pytest --cov-report xml --cov=src
 
 format:
 	python3 -m ruff check --select I --fix

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-ignore:
-  - "test/"


### PR DESCRIPTION
This fixes the issue where code coverage is only being collected on `examples/`, instead of `src/`. 

The solution was to explicitly specify `src/manta` as the path to collect coverage over, and then to use a editable installation (`pip install -e`) in CI. This prevents the CI from installing the package into the `venv`, and then executing files from that installation instead of using what's in `src/manta`.